### PR TITLE
Fix crc, add setname and rotation

### DIFF
--- a/releases/BlockBuster.mra
+++ b/releases/BlockBuster.mra
@@ -1,5 +1,6 @@
 <misterromdescription>
 	<name>BlockBuster</name>
+	<setname>blkbustr</setname>
 	<homebrew>no</homebrew>
 	<bootleg>no</bootleg>
 	<series></series>
@@ -9,7 +10,7 @@
 	<rbf>mrjong</rbf>
 	<about></about>
 	<resolution>15kHz</resolution>
-	<rotation>vertical</rotation>
+	<rotation>vertical (cw)</rotation>
 	<flip></flip>
 	<players>2</players>
 	<joystick>4-way</joystick>

--- a/releases/Crazy Blocks.mra
+++ b/releases/Crazy Blocks.mra
@@ -1,6 +1,6 @@
 <misterromdescription>
-	<name>BlockBuster</name>
-	<setname>blkbustr</setname>
+	<name>Crazy Blocks</name>
+	<setname>crazyblk</setname>
 	<homebrew>no</homebrew>
 	<bootleg>no</bootleg>
 	<series></series>
@@ -25,15 +25,15 @@
 		<dip bits="4,5" name="Lives" ids="6,4,5,3"/>
 		<dip bits="6,7" name="Coin" ids="1c/1c,1c/2c,1c/3c,2c/1c"/>
 	</switches>
-	<rom index="0" zip="blkbustr.zip|mrjong.zip" md5="none">
+	<rom index="0" zip="crazyblk.zip|mrjong.zip" md5="none">
 		<!-- main cpu -->
-		<part name="6a.bin" crc="9e4b426c"/>
+		<part name="c1.a6" crc="e2a211a2"/>
 		<part name="c2.a7" crc="75070978"/>
-		<part name="8a.bin" crc="0e803777"/>
+		<part name="c3.a7" crc="696ca502"/>
 		<part name="c4.a8" crc="c7f5a247"/>
 		<!-- gfx -->
-		<part name="4h.bin" crc="67dd6c19"/>
-		<part name="5h.bin" crc="50fba1d4"/>
+		<part name="c6.h5" crc="2b2af794"/>
+		<part name="c5.h4" crc="98d13915"/>
 		<!-- prom -->
 		<part name="clr.j7"  crc="ee1cf1d5"/>
 		<part name="clr.g5"  crc="bcb1e2e3"/>

--- a/releases/CrazyBlocks.mra
+++ b/releases/CrazyBlocks.mra
@@ -1,5 +1,6 @@
 <misterromdescription>
 	<name>Crazy Blocks</name>
+	<setname>crazyblk</setname>
 	<homebrew>no</homebrew>
 	<bootleg>no</bootleg>
 	<series></series>
@@ -9,7 +10,7 @@
 	<rbf>mrjong</rbf>
 	<about></about>
 	<resolution>15kHz</resolution>
-	<rotation>vertical</rotation>
+	<rotation>vertical (cw)</rotation>
 	<flip></flip>
 	<players>2</players>
 	<joystick>4-way</joystick>

--- a/releases/Mr. Jong.mra
+++ b/releases/Mr. Jong.mra
@@ -1,11 +1,11 @@
 <misterromdescription>
-	<name>BlockBuster</name>
-	<setname>blkbustr</setname>
+	<name>Mr.Jong</name>
+	<setname>mrjong</setname>
 	<homebrew>no</homebrew>
 	<bootleg>no</bootleg>
 	<series></series>
 	<year>1983</year>
-	<manufacturer>Kiwako (ECI license)</manufacturer>
+	<manufacturer>Kiwako</manufacturer>
 	<category>Puzzle</category>
 	<rbf>mrjong</rbf>
 	<about></about>
@@ -25,18 +25,18 @@
 		<dip bits="4,5" name="Lives" ids="6,4,5,3"/>
 		<dip bits="6,7" name="Coin" ids="1c/1c,1c/2c,1c/3c,2c/1c"/>
 	</switches>
-	<rom index="0" zip="blkbustr.zip|mrjong.zip" md5="none">
+	<rom index="0" zip="mrjong.zip" md5="none">
 		<!-- main cpu -->
-		<part name="6a.bin" crc="9e4b426c"/>
-		<part name="c2.a7" crc="75070978"/>
-		<part name="8a.bin" crc="0e803777"/>
-		<part name="c4.a8" crc="c7f5a247"/>
+		<part name="mj00" crc="d211aed3"/>
+		<part name="mj01" crc="49a9ca7e"/>
+		<part name="mj02" crc="4b50ae6a"/>
+		<part name="mj03" crc="2c375a17"/>
 		<!-- gfx -->
-		<part name="4h.bin" crc="67dd6c19"/>
-		<part name="5h.bin" crc="50fba1d4"/>
+		<part name="mj20" crc="7eb1d381"/>
+		<part name="mj21" crc="1ea99dab"/>
 		<!-- prom -->
-		<part name="clr.j7"  crc="ee1cf1d5"/>
-		<part name="clr.g5"  crc="bcb1e2e3"/>
+		<part name="mj61"  crc="a85e9b27"/>
+		<part name="mj60"  crc="dd2b304f"/>
 	</rom>
 	<rom index="1"></rom>
 	<rom index="2"></rom>

--- a/releases/MrJong.mra
+++ b/releases/MrJong.mra
@@ -1,5 +1,6 @@
 <misterromdescription>
 	<name>Mr.Jong</name>
+	<setname>mrjong</setname>
 	<homebrew>no</homebrew>
 	<bootleg>no</bootleg>
 	<series></series>
@@ -9,7 +10,7 @@
 	<rbf>mrjong</rbf>
 	<about></about>
 	<resolution>15kHz</resolution>
-	<rotation>vertical</rotation>
+	<rotation>vertical (cw)</rotation>
 	<flip></flip>
 	<players>2</players>
 	<joystick>4-way</joystick>


### PR DESCRIPTION
Hi Pierco,
This pull request does the following:
1. I have corrected the crcs for the mras so now they are booting the correct rom.
2. I added setnames to the mra. 
3. Added corrected rotation
4. Fixed names so that they follow MAME 