### PR TITLE
Change mra rotation to match core output

### DIFF
--- a/releases/Mr. Jong.mra
+++ b/releases/Mr. Jong.mra
@@ -10,7 +10,7 @@
 	<rbf>mrjong</rbf>
 	<about></about>
 	<resolution>15kHz</resolution>
-	<rotation>vertical (cw)</rotation>
+	<rotation>vertical (ccw)</rotation>
 	<flip></flip>
 	<players>2</players>
 	<joystick>4-way</joystick>
@@ -46,3 +46,4 @@
 	<remark></remark>
 	<!-- <mratimestamp></mratimestamp> -->
 </misterromdescription>
+


### PR DESCRIPTION
According to mame, the core should be outputting CW video, but it's currently CCW. 

Because the direct video infoframe uses the MRA to determine rotation direction, it should match the core output.

Claude and I tried to rotate the video in the core, but all we managed to do is invert it. This is an easier fix, even if the MRA no longer matches MAME.